### PR TITLE
Fixes issues #1 and #2

### DIFF
--- a/parse.py
+++ b/parse.py
@@ -47,7 +47,7 @@ class Parser:
 
     def parse_quotes(self, page_number):
         html = self.fetch_page(page_number)
-        soup = BeautifulSoup(html, "html.parser")
+        soup = BeautifulSoup(html, "lxml")
         quote_divs = soup.find_all("div", class_="quote")
         for quote_div in quote_divs:
             quote = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 beautifulsoup4
+python-lxml


### PR DESCRIPTION
Changing the parser to "lxml" allows to avoid issues with unclosed \<br\> tags, which are used on bash.im.